### PR TITLE
In mtdome/recover_from_controller_fault.py, update timeout used to wa…

### DIFF
--- a/doc/news/OSW-1968.misc.rst
+++ b/doc/news/OSW-1968.misc.rst
@@ -1,0 +1,1 @@
+In mtdome/recover_from_controller_fault.py, update timeout used to wait for in_position event and capture slew_dome faults to prevent script from failing before additional recovery attempts.

--- a/python/lsst/ts/maintel/standardscripts/mtdome/recover_from_controller_fault.py
+++ b/python/lsst/ts/maintel/standardscripts/mtdome/recover_from_controller_fault.py
@@ -60,6 +60,7 @@ class RecoverFromControllerFault(salobj.BaseScript):
         )
         self.mtcs = None
         self.exitFault_subSystemIds = SubSystemId.AMCS  # Azimuth Motion Control System
+        self.fast_dome_move_timeout = 30
 
     @classmethod
     def get_schema(cls):
@@ -110,8 +111,8 @@ class RecoverFromControllerFault(salobj.BaseScript):
             )
 
     def set_metadata(self, metadata):
-        # An estimate based on slew_to() operation.
-        metadata.duration = self.mtcs.long_long_timeout + self.mtcs.move_dome_timeout
+        # An estimate based on slew_to() operation and fast timeout
+        metadata.duration = self.mtcs.long_long_timeout + self.fast_dome_move_timeout
 
     async def run(self):
         # Check MTDome following state and disable dome following if necessary
@@ -151,7 +152,8 @@ class RecoverFromControllerFault(salobj.BaseScript):
                 self.log.warning(
                     f"Dome did not reach target position on attempt {attempt}. Retrying..."
                 )
-                target_az = (final_az + self.config.delta_move) % 360
+                if final_az is not None:
+                    target_az = (final_az + self.config.delta_move) % 360
 
         # Enable the dome following.
         await self.mtcs.enable_dome_following()
@@ -170,7 +172,14 @@ class RecoverFromControllerFault(salobj.BaseScript):
 
     async def move_dome_and_check_success(self, target_az):
         self.log.info(f"Attempting to slew dome to {target_az} deg...")
-        await self.mtcs.slew_dome_to(az=target_az)
+        try:
+            await self.mtcs.slew_dome_to(
+                az=target_az, timeout=self.fast_dome_move_timeout
+            )
+        except Exception as err:
+            self.log.warning(f"slew dome failed: {err}")
+            return False, None
+
         after_slew_az = await self.mtcs.rem.mtdome.tel_azimuth.next(
             flush=True, timeout=self.mtcs.fast_timeout
         )

--- a/tests/test_maintel_mtdome_recover_from_controller_fault.py
+++ b/tests/test_maintel_mtdome_recover_from_controller_fault.py
@@ -119,7 +119,9 @@ class TestRecoverFromControllerFault(
             self.script.mtcs.rem.mtdome.cmd_exitFault.set_start.assert_awaited_once_with(
                 subSystemIds=SubSystemId.AMCS, timeout=self.script.mtcs.fast_timeout
             )
-            self.script.mtcs.slew_dome_to.assert_awaited_once_with(az=target_az)
+            self.script.mtcs.slew_dome_to.assert_awaited_once_with(
+                az=target_az, timeout=self.script.fast_dome_move_timeout
+            )
             self.script.mtcs.enable_dome_following.assert_awaited_once()
 
     async def test_run_success_dome_following_disabled(self):
@@ -148,7 +150,9 @@ class TestRecoverFromControllerFault(
             self.script.mtcs.rem.mtdome.cmd_exitFault.set_start.assert_awaited_once_with(
                 subSystemIds=SubSystemId.AMCS, timeout=self.script.mtcs.fast_timeout
             )
-            self.script.mtcs.slew_dome_to.assert_awaited_once_with(az=target_az)
+            self.script.mtcs.slew_dome_to.assert_awaited_once_with(
+                az=target_az, timeout=self.script.fast_dome_move_timeout
+            )
             self.script.mtcs.enable_dome_following.assert_awaited_once()
 
     async def test_run_success_after_failing_exitFault(self):
@@ -191,7 +195,10 @@ class TestRecoverFromControllerFault(
             )
             # Check slew dome attempts
             expected_slew_dome_to_calls = [
-                unittest.mock.call(az=offset_az + delta_move)
+                unittest.mock.call(
+                    az=offset_az + delta_move,
+                    timeout=self.script.fast_dome_move_timeout,
+                )
                 for offset_az in az_positions[:-1]
             ]
             self.script.mtcs.slew_dome_to.assert_has_awaits(expected_slew_dome_to_calls)
@@ -230,7 +237,10 @@ class TestRecoverFromControllerFault(
             )
             # Check slew dome attempts
             expected_slew_dome_to_calls = [
-                unittest.mock.call(az=offset_az + delta_move)
+                unittest.mock.call(
+                    az=offset_az + delta_move,
+                    timeout=self.script.fast_dome_move_timeout,
+                )
                 for offset_az in az_positions[:-1]
             ]
             self.script.mtcs.slew_dome_to.assert_has_awaits(expected_slew_dome_to_calls)
@@ -303,7 +313,9 @@ class TestRecoverFromControllerFault(
             )
             # Check slew dome attempts
             expected_slew_dome_to_calls = [
-                unittest.mock.call(az=target_az)
+                unittest.mock.call(
+                    az=target_az, timeout=self.script.fast_dome_move_timeout
+                )
                 for i in range(self.script.MAX_ATTEMPTS)
             ]
             self.script.mtcs.slew_dome_to.assert_has_awaits(expected_slew_dome_to_calls)
@@ -347,7 +359,10 @@ class TestRecoverFromControllerFault(
             )
             # Check slew dome attempts
             expected_slew_dome_to_calls = [
-                unittest.mock.call(az=offset_az + delta_move)
+                unittest.mock.call(
+                    az=offset_az + delta_move,
+                    timeout=self.script.fast_dome_move_timeout,
+                )
                 for offset_az in az_positions[:-1]
             ]
             self.script.mtcs.slew_dome_to.assert_has_awaits(expected_slew_dome_to_calls)


### PR DESCRIPTION
…it for in_position event and capture slew_dome faults to prevent script from failing before additional recovery attempts.